### PR TITLE
improve performance of cpf algorithm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 *.out
 .DS_Store
 go.work
+*.txt

--- a/address.go
+++ b/address.go
@@ -341,11 +341,10 @@ func (cep CEP) IsValid() bool {
 			cur = cep[i+pad]
 		}
 
-		if cur < '0' || cur > '9' {
+		if !isDigit(cur) {
 			return false
 		}
 	}
-
 	return !invalidCEPs.Contains(string(cep))
 }
 

--- a/cnpj.go
+++ b/cnpj.go
@@ -82,7 +82,7 @@ func iterCNPJTable(cnpj CNPJ, table []int) (byte, bool) {
 
 		cur = asciiLowerToUpper(cur)
 
-		if cur < '0' || (cur > '9' && cur < 'A') || cur > 'Z' {
+		if !isAlphaNumericalUpper(cur) {
 			return 0, false
 		}
 
@@ -141,13 +141,6 @@ func (cnpj CNPJ) String() string {
 	}
 
 	return unsafex.String(out)
-}
-
-func asciiLowerToUpper(b byte) byte {
-	if b >= 'a' && b <= 'z' {
-		b -= 'a' - 'A'
-	}
-	return b
 }
 
 func (cnpj CNPJ) Value() (driver.Value, error) {

--- a/cnpj_test.go
+++ b/cnpj_test.go
@@ -2,8 +2,6 @@ package br
 
 import "testing"
 
-var sink bool
-
 func BenchmarkCNPJ_IsValid(b *testing.B) {
 	const cnpjPetrobras = CNPJ("33.000.167/1002-46")
 	if !cnpjPetrobras.IsValid() {
@@ -12,7 +10,7 @@ func BenchmarkCNPJ_IsValid(b *testing.B) {
 	}
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		sink = cnpjPetrobras.IsValid()
+		boolSink = cnpjPetrobras.IsValid()
 	}
 }
 

--- a/cns.go
+++ b/cns.go
@@ -47,7 +47,7 @@ func (cns CNS) IsValid() bool {
 			cur = cns[i+pad]
 		}
 
-		if cur < '0' || cur > '9' {
+		if !isDigit(cur) {
 			return false
 		}
 

--- a/cns_test.go
+++ b/cns_test.go
@@ -13,7 +13,7 @@ func BenchmarkCNS_IsValid(b *testing.B) {
 	}
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		sink = randomCNS.IsValid()
+		boolSink = randomCNS.IsValid()
 	}
 }
 

--- a/cpf_test.go
+++ b/cpf_test.go
@@ -2,7 +2,7 @@ package br
 
 import "testing"
 
-func BenchmarkCPF_IsValid(b *testing.B) {
+func BenchmarkCPF_IsValid14(b *testing.B) {
 	const cpfBolsonaro = CPF("453.178.287-91")
 	if !cpfBolsonaro.IsValid() {
 		b.Error("invalid cpfBolsonaro on benchmark")
@@ -10,7 +10,67 @@ func BenchmarkCPF_IsValid(b *testing.B) {
 	}
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		sink = cpfBolsonaro.IsValid()
+		boolSink = cpfBolsonaro.IsValid()
+	}
+}
+
+func BenchmarkCPF_IsValid11(b *testing.B) {
+	const cpfBolsonaro = CPF("45317828791")
+	if !cpfBolsonaro.IsValid() {
+		b.Error("invalid cpfBolsonaro on benchmark")
+		b.FailNow()
+	}
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		boolSink = cpfBolsonaro.IsValid()
+	}
+}
+
+func BenchmarkCPF_IsValid14Invalid(b *testing.B) {
+	const cpfBolsonaro = CPF("453.178.287-92")
+	if cpfBolsonaro.IsValid() {
+		b.Error("valid cpfBolsonaro on benchmark")
+		b.FailNow()
+	}
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		boolSink = cpfBolsonaro.IsValid()
+	}
+}
+
+func BenchmarkCPF_IsValid11Invalid(b *testing.B) {
+	const cpfBolsonaro = CPF("45317828792")
+	if cpfBolsonaro.IsValid() {
+		b.Error("valid cpfBolsonaro on benchmark")
+		b.FailNow()
+	}
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		boolSink = cpfBolsonaro.IsValid()
+	}
+}
+
+func BenchmarkCPF_String14(b *testing.B) {
+	const cpfBolsonaro = CPF("453.178.287-91")
+	if !cpfBolsonaro.IsValid() {
+		b.Error("invalid cpfBolsonaro on benchmark")
+		b.FailNow()
+	}
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		stringSink = cpfBolsonaro.String()
+	}
+}
+
+func BenchmarkCPF_String11(b *testing.B) {
+	const cpfBolsonaro = CPF("45317828791")
+	if !cpfBolsonaro.IsValid() {
+		b.Error("invalid cpfBolsonaro on benchmark")
+		b.FailNow()
+	}
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		stringSink = cpfBolsonaro.String()
 	}
 }
 
@@ -37,7 +97,7 @@ func TestCPF_IsValid(t *testing.T) {
 		},
 		{
 			name:  "invalid first digit raw CPF Bolsonaro",
-			cpf:   CPF("453.178.287-81"),
+			cpf:   CPF("45317828781"),
 			valid: false,
 		},
 		{
@@ -47,7 +107,7 @@ func TestCPF_IsValid(t *testing.T) {
 		},
 		{
 			name:  "invalid second digit raw CPF Bolsonaro",
-			cpf:   CPF("453.178.287-92"),
+			cpf:   CPF("45317828792"),
 			valid: false,
 		},
 	} {

--- a/plate.go
+++ b/plate.go
@@ -45,7 +45,7 @@ func (p Plate) IsValid() bool {
 	for i := 0; i < 7; i++ {
 		switch cur := p[i+pad]; {
 		case i < 3:
-			if cur < 'A' || cur > 'Z' {
+			if !isAlphaUpper(cur) {
 				return false
 			}
 		case i == 3:
@@ -54,16 +54,15 @@ func (p Plate) IsValid() bool {
 				cur = p[i+pad]
 			}
 
-			if cur < '0' || cur > '9' {
+			if !isDigit(cur) {
 				return false
 			}
 		case i == 4:
-			if (cur < 'A' || cur > 'Z') &&
-				(cur < '0' || cur > '9') {
+			if !isAlphaNumericalUpper(cur) {
 				return false
 			}
 		default:
-			if cur < '0' || cur > '9' {
+			if !isDigit(cur) {
 				return false
 			}
 		}

--- a/plate_test.go
+++ b/plate_test.go
@@ -10,7 +10,7 @@ func BenchmarkPlate_IsValid(b *testing.B) {
 	}
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		sink = plate.IsValid()
+		boolSink = plate.IsValid()
 	}
 }
 

--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,20 @@
+package br
+
+func isDigit(b byte) bool {
+	return b >= '0' && b <= '9'
+}
+
+func isAlphaUpper(b byte) bool {
+	return b >= 'A' && b <= 'Z'
+}
+
+func isAlphaNumericalUpper(b byte) bool {
+	return isDigit(b) || isAlphaUpper(b)
+}
+
+func asciiLowerToUpper(b byte) byte {
+	if b >= 'a' && b <= 'z' {
+		b -= 'a' - 'A'
+	}
+	return b
+}

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,0 +1,6 @@
+package br
+
+var (
+	boolSink   bool
+	stringSink string
+)


### PR DESCRIPTION
```
goos: linux
goarch: amd64
pkg: github.com/phenpessoa/br
cpu: Intel(R) Core(TM) Ultra 7 155H
                        │   old.txt   │               new.txt               │
                        │   sec/op    │   sec/op     vs base                │
CPF_IsValid14-21          26.88n ± 1%   15.01n ± 2%  -44.15% (p=0.000 n=10)
CPF_IsValid11-21          21.53n ± 2%   13.98n ± 3%  -35.05% (p=0.000 n=10)
CPF_IsValid14Invalid-21   26.57n ± 2%   14.93n ± 1%  -43.82% (p=0.000 n=10)
CPF_IsValid11Invalid-21   21.77n ± 2%   14.15n ± 2%  -34.98% (p=0.000 n=10)
CPF_String14-21           26.91n ± 1%   15.99n ± 2%  -40.56% (p=0.000 n=10)
CPF_String11-21           50.65n ± 1%   27.89n ± 2%  -44.94% (p=0.000 n=10)
geomean                   27.75n        16.45n       -40.73%
```