### PR TITLE
perf: improve performance of cnpj algorithm

### DIFF
--- a/address.go
+++ b/address.go
@@ -524,7 +524,7 @@ func viaCEP(cep CEP) (Address, error) {
 		)
 	}
 
-	if dados.Erro || dados.Address.CEP == "" {
+	if dados.Erro || dados.CEP == "" {
 		return Address{}, ErrInvalidCEP
 	}
 

--- a/cnpj.go
+++ b/cnpj.go
@@ -22,35 +22,6 @@ func NewCNPJ(s string) (CNPJ, error) {
 	return cnpj, nil
 }
 
-func GenerateCNPJ() CNPJ {
-	data := make([]byte, 18)
-	data[2] = '.'
-	data[6] = '.'
-	data[10] = '/'
-	data[15] = '-'
-
-	for i := range 2 {
-		data[i] = randomAlphaNumericalUpper()
-	}
-
-	for i := 3; i < 6; i++ {
-		data[i] = randomAlphaNumericalUpper()
-	}
-
-	for i := 7; i < 10; i++ {
-		data[i] = randomAlphaNumericalUpper()
-	}
-
-	for i := 11; i < 15; i++ {
-		data[i] = randomAlphaNumericalUpper()
-	}
-
-	data[16], _ = cnpjIterFirst18(data)
-	data[17], _ = cnpjIterSecond18(data)
-
-	return CNPJ(string(data))
-}
-
 // ErrInvalidCNPJ is an error returned when an invalid CNPJ is encountered.
 var ErrInvalidCNPJ = errors.New("br: invalid cnpj")
 

--- a/cnpj.go
+++ b/cnpj.go
@@ -8,13 +8,8 @@ import (
 	"github.com/phenpessoa/gutils/unsafex"
 )
 
-var (
-	// ErrInvalidCNPJ is an error returned when an invalid CNPJ is encountered.
-	ErrInvalidCNPJ = errors.New("br: invalid cnpj passed")
-
-	cnpjFirstTable  = []int{5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2}
-	cnpjSecondTable = []int{6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2}
-)
+// CNPJ represents a Brazilian CNPJ.
+type CNPJ string
 
 // NewCNPJ creates a new CNPJ instance from a string representation.
 //
@@ -27,75 +22,241 @@ func NewCNPJ(s string) (CNPJ, error) {
 	return cnpj, nil
 }
 
-// CNPJ represents a Brazilian CNPJ.
-type CNPJ string
+func GenerateCNPJ() CNPJ {
+	data := make([]byte, 18)
+	data[2] = '.'
+	data[6] = '.'
+	data[10] = '/'
+	data[15] = '-'
+
+	for i := range 2 {
+		data[i] = randomAlphaNumericalUpper()
+	}
+
+	for i := 3; i < 6; i++ {
+		data[i] = randomAlphaNumericalUpper()
+	}
+
+	for i := 7; i < 10; i++ {
+		data[i] = randomAlphaNumericalUpper()
+	}
+
+	for i := 11; i < 15; i++ {
+		data[i] = randomAlphaNumericalUpper()
+	}
+
+	data[16], _ = cnpjIterFirst18(data)
+	data[17], _ = cnpjIterSecond18(data)
+
+	return CNPJ(string(data))
+}
+
+// ErrInvalidCNPJ is an error returned when an invalid CNPJ is encountered.
+var ErrInvalidCNPJ = errors.New("br: invalid cnpj")
+
+// cnpj tables
+var (
+	cnpjFirstTable  = []int{5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2}
+	cnpjSecondTable = []int{6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2}
+)
 
 // IsValid checks whether the provided CNPJ is valid based on its checksum
 // digits.
 func (cnpj CNPJ) IsValid() bool {
-	l := len(cnpj)
-	if l != 14 && l != 18 {
-		return false
-	}
-
-	dByte, ok := iterCNPJTable(cnpj, cnpjFirstTable)
-	if !ok {
-		return false
-	}
-	if cnpj[l-2] != dByte {
-		return false
-	}
-
-	dByte, ok = iterCNPJTable(cnpj, cnpjSecondTable)
-	if !ok {
-		return false
-	}
-
-	return cnpj[l-1] == dByte
-}
-
-func iterCNPJTable(cnpj CNPJ, table []int) (byte, bool) {
-	var sum, pad, rest, d int
-
-	for i, d := range table {
-		cur := cnpj[i+pad]
-		switch cur {
-		case '.':
-			if i != 2 && i != 5 {
-				return 0, false
-			}
-			pad++
-			cur = cnpj[i+pad]
-		case '/':
-			if i != 8 {
-				return 0, false
-			}
-			pad++
-			cur = cnpj[i+pad]
-		case '-':
-			if i != 12 {
-				return 0, false
-			}
-			pad++
-			cur = cnpj[i+pad]
+	switch len(cnpj) {
+	case 14:
+		dByte, ok := cnpjIterFirst14(cnpj)
+		if !ok {
+			return false
 		}
 
-		cur = asciiLowerToUpper(cur)
+		if cnpj[len(cnpj)-2] != dByte {
+			return false
+		}
 
+		dByte, ok = cnpjIterSecond14(cnpj)
+		if !ok {
+			return false
+		}
+
+		return cnpj[len(cnpj)-1] == dByte
+	case 18:
+		if cnpj[2] != '.' || cnpj[6] != '.' || cnpj[10] != '/' || cnpj[15] != '-' {
+			return false
+		}
+
+		dByte, ok := cnpjIterFirst18(cnpj)
+		if !ok {
+			return false
+		}
+
+		if cnpj[len(cnpj)-2] != dByte {
+			return false
+		}
+
+		dByte, ok = cnpjIterSecond18(cnpj)
+		if !ok {
+			return false
+		}
+
+		return cnpj[len(cnpj)-1] == dByte
+	default:
+		return false
+	}
+}
+
+func cnpjIterFirst18[T string | CNPJ | []byte](cnpj T) (byte, bool) {
+	if len(cnpj) != 18 || len(cnpjFirstTable) != 12 {
+		panic("not 18 or 12")
+	}
+
+	var sum, rest, out int
+	for i, d := range cnpjFirstTable[:2] {
+		cur := asciiLowerToUpper(cnpj[i])
 		if !isAlphaNumericalUpper(cur) {
 			return 0, false
 		}
+		sum += d * int(cur-'0')
+	}
 
+	for i, d := range cnpjFirstTable[2:5] {
+		cur := asciiLowerToUpper(cnpj[3:6][i])
+		if !isAlphaNumericalUpper(cur) {
+			return 0, false
+		}
+		sum += d * int(cur-'0')
+	}
+
+	for i, d := range cnpjFirstTable[5:8] {
+		cur := asciiLowerToUpper(cnpj[7:10][i])
+		if !isAlphaNumericalUpper(cur) {
+			return 0, false
+		}
+		sum += d * int(cur-'0')
+	}
+
+	for i, d := range cnpjFirstTable[8:12] {
+		cur := asciiLowerToUpper(cnpj[11:15][i])
+		if !isAlphaNumericalUpper(cur) {
+			return 0, false
+		}
 		sum += d * int(cur-'0')
 	}
 
 	rest = sum % 11
 
 	if rest >= 2 {
-		d = 11 - rest
+		out = 11 - rest
 	}
 
-	return byte(d) + '0', true
+	return byte(out) + '0', true
+}
+
+func cnpjIterSecond18[T string | CNPJ | []byte](cnpj T) (byte, bool) {
+	if len(cnpj) != 18 || len(cnpjSecondTable) != 13 {
+		panic("not 18 or 12")
+	}
+
+	var sum, rest, out int
+	for i, d := range cnpjSecondTable[:2] {
+		cur := asciiLowerToUpper(cnpj[i])
+		if !isAlphaNumericalUpper(cur) {
+			return 0, false
+		}
+		sum += d * int(cur-'0')
+	}
+
+	for i, d := range cnpjSecondTable[2:5] {
+		cur := asciiLowerToUpper(cnpj[3:6][i])
+		if !isAlphaNumericalUpper(cur) {
+			return 0, false
+		}
+		sum += d * int(cur-'0')
+	}
+
+	for i, d := range cnpjSecondTable[5:8] {
+		cur := asciiLowerToUpper(cnpj[7:10][i])
+		if !isAlphaNumericalUpper(cur) {
+			return 0, false
+		}
+		sum += d * int(cur-'0')
+	}
+
+	for i, d := range cnpjSecondTable[8:12] {
+		cur := asciiLowerToUpper(cnpj[11:15][i])
+		if !isAlphaNumericalUpper(cur) {
+			return 0, false
+		}
+		sum += d * int(cur-'0')
+	}
+
+	last := cnpj[16]
+	if !isDigit(last) {
+		return 0, false
+	}
+	sum += cnpjSecondTable[12] * int(last-'0')
+
+	rest = sum % 11
+
+	if rest >= 2 {
+		out = 11 - rest
+	}
+
+	return byte(out) + '0', true
+}
+
+func cnpjIterFirst14[T string | CNPJ | []byte](cnpj T) (byte, bool) {
+	if len(cnpj) != 14 || len(cnpjFirstTable) != 12 {
+		panic("not 14 or 12")
+	}
+
+	var sum, rest, out int
+
+	for i, d := range cnpjFirstTable {
+		cur := asciiLowerToUpper(cnpj[i])
+		if !isAlphaNumericalUpper(cur) {
+			return 0, false
+		}
+		sum += d * int(cur-'0')
+	}
+
+	rest = sum % 11
+
+	if rest >= 2 {
+		out = 11 - rest
+	}
+
+	return byte(out) + '0', true
+}
+
+func cnpjIterSecond14[T string | CNPJ | []byte](cnpj T) (byte, bool) {
+	if len(cnpj) != 14 || len(cnpjSecondTable) != 13 {
+		panic("not 14 or 12")
+	}
+
+	var sum, rest, out int
+
+	for i, d := range cnpjSecondTable[:12] {
+		cur := asciiLowerToUpper(cnpj[i])
+		if !isAlphaNumericalUpper(cur) {
+			return 0, false
+		}
+		sum += d * int(cur-'0')
+	}
+
+	last := cnpj[12]
+	if !isDigit(last) {
+		return 0, false
+	}
+	sum += cnpjSecondTable[12] * int(last-'0')
+
+	rest = sum % 11
+
+	if rest >= 2 {
+		out = 11 - rest
+	}
+
+	return byte(out) + '0', true
 }
 
 // String returns the formatted CNPJ string with punctuation as

--- a/cnpj_test.go
+++ b/cnpj_test.go
@@ -2,15 +2,75 @@ package br
 
 import "testing"
 
-func BenchmarkCNPJ_IsValid(b *testing.B) {
-	const cnpjPetrobras = CNPJ("33.000.167/1002-46")
-	if !cnpjPetrobras.IsValid() {
-		b.Error("invalid cnpjPetrobras on benchmark")
+func BenchmarkCNPJ_IsValid18(b *testing.B) {
+	const cnpj = CNPJ("33.000.167/1002-46")
+	if !cnpj.IsValid() {
+		b.Error("invalid cnpj on benchmark")
 		b.FailNow()
 	}
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		boolSink = cnpjPetrobras.IsValid()
+	for range b.N {
+		boolSink = cnpj.IsValid()
+	}
+}
+
+func BenchmarkCNPJ_IsValid14(b *testing.B) {
+	const cnpj = CNPJ("33000167100246")
+	if !cnpj.IsValid() {
+		b.Error("invalid cnpj on benchmark")
+		b.FailNow()
+	}
+	b.ReportAllocs()
+	for range b.N {
+		boolSink = cnpj.IsValid()
+	}
+}
+
+func BenchmarkCNPJ_IsValid18Invalid(b *testing.B) {
+	const cnpj = CNPJ("33.000.167/1002-47")
+	if cnpj.IsValid() {
+		b.Error("valid cnpj on benchmark")
+		b.FailNow()
+	}
+	b.ReportAllocs()
+	for range b.N {
+		boolSink = cnpj.IsValid()
+	}
+}
+
+func BenchmarkCNPJ_IsValid14Invalid(b *testing.B) {
+	const cnpj = CNPJ("33000167100247")
+	if cnpj.IsValid() {
+		b.Error("valid cnpj on benchmark")
+		b.FailNow()
+	}
+	b.ReportAllocs()
+	for range b.N {
+		boolSink = cnpj.IsValid()
+	}
+}
+
+func BenchmarkCNPJ_String18(b *testing.B) {
+	const cnpj = CNPJ("33.000.167/1002-46")
+	if !cnpj.IsValid() {
+		b.Error("invalid cnpj on benchmark")
+		b.FailNow()
+	}
+	b.ReportAllocs()
+	for range b.N {
+		stringSink = cnpj.String()
+	}
+}
+
+func BenchmarkCNPJ_String14(b *testing.B) {
+	const cnpj = CNPJ("33000167100246")
+	if !cnpj.IsValid() {
+		b.Error("invalid cnpj on benchmark")
+		b.FailNow()
+	}
+	b.ReportAllocs()
+	for range b.N {
+		stringSink = cnpj.String()
 	}
 }
 
@@ -93,6 +153,16 @@ func TestCNPJ_IsValid(t *testing.T) {
 		{
 			name:  "formatted CNPJ alfanumerico 2",
 			cnpj:  CNPJ("AB.CDE.FGI/HIJK-56"),
+			valid: true,
+		},
+		{
+			name:  "raw alfanumerico 3",
+			cnpj:  CNPJ("12ABC34501DE35"),
+			valid: true,
+		},
+		{
+			name:  "formatted alfanumerico 3",
+			cnpj:  CNPJ("12.ABC.345/01DE-35"),
 			valid: true,
 		},
 	} {

--- a/cpf.go
+++ b/cpf.go
@@ -3,7 +3,6 @@ package br
 import (
 	"database/sql/driver"
 	"errors"
-	"math/rand/v2"
 )
 
 // CPF represents a Brazilian CPF.
@@ -26,8 +25,6 @@ func GenerateCPF() CPF {
 	data[7] = '.'
 	data[11] = '-'
 
-	rand.Int32N(2)
-
 	for i := range 3 {
 		data[i] = randomDigit()
 	}
@@ -40,14 +37,14 @@ func GenerateCPF() CPF {
 		data[i] = randomDigit()
 	}
 
-	data[12], _ = iterFirst14(data)
-	data[13], _ = iterSecond14(data)
+	data[12], _ = cpfIterFirst14(data)
+	data[13], _ = cpfIterSecond14(data)
 
 	return CPF(string(data))
 }
 
 // ErrInvalidCPF is an error returned when an invalid CPF is encountered.
-var ErrInvalidCPF = errors.New("br: invalid cpf passed")
+var ErrInvalidCPF = errors.New("br: invalid cpf")
 
 // cpf tables
 var (
@@ -60,7 +57,7 @@ var (
 func (cpf CPF) IsValid() bool {
 	switch len(cpf) {
 	case 11:
-		dByte, ok := iterFirst11(cpf)
+		dByte, ok := cpfIterFirst11(cpf)
 		if !ok {
 			return false
 		}
@@ -69,7 +66,7 @@ func (cpf CPF) IsValid() bool {
 			return false
 		}
 
-		dByte, ok = iterSecond11(cpf)
+		dByte, ok = cpfIterSecond11(cpf)
 		if !ok {
 			return false
 		}
@@ -80,7 +77,7 @@ func (cpf CPF) IsValid() bool {
 			return false
 		}
 
-		dByte, ok := iterFirst14(cpf)
+		dByte, ok := cpfIterFirst14(cpf)
 		if !ok {
 			return false
 		}
@@ -89,7 +86,7 @@ func (cpf CPF) IsValid() bool {
 			return false
 		}
 
-		dByte, ok = iterSecond14(cpf)
+		dByte, ok = cpfIterSecond14(cpf)
 		if !ok {
 			return false
 		}
@@ -100,7 +97,7 @@ func (cpf CPF) IsValid() bool {
 	}
 }
 
-func iterFirst14[T string | CPF | []byte](cpf T) (byte, bool) {
+func cpfIterFirst14[T string | CPF | []byte](cpf T) (byte, bool) {
 	if len(cpf) != 14 || len(cpfFirstTable) != 9 {
 		panic("not 14 or 9")
 	}
@@ -140,7 +137,7 @@ func iterFirst14[T string | CPF | []byte](cpf T) (byte, bool) {
 	return byte(out) + '0', true
 }
 
-func iterSecond14[T string | CPF | []byte](cpf T) (byte, bool) {
+func cpfIterSecond14[T string | CPF | []byte](cpf T) (byte, bool) {
 	if len(cpf) != 14 || len(cpfSecondTable) != 10 {
 		panic("not 14 or 10")
 	}
@@ -186,7 +183,7 @@ func iterSecond14[T string | CPF | []byte](cpf T) (byte, bool) {
 	return byte(out) + '0', true
 }
 
-func iterFirst11[T string | CPF | []byte](cpf T) (byte, bool) {
+func cpfIterFirst11[T string | CPF | []byte](cpf T) (byte, bool) {
 	if len(cpf) != 11 || len(cpfFirstTable) != 9 {
 		panic("not 11 or 9")
 	}
@@ -210,7 +207,7 @@ func iterFirst11[T string | CPF | []byte](cpf T) (byte, bool) {
 	return byte(out) + '0', true
 }
 
-func iterSecond11[T string | CPF | []byte](cpf T) (byte, bool) {
+func cpfIterSecond11[T string | CPF | []byte](cpf T) (byte, bool) {
 	if len(cpf) != 11 || len(cpfSecondTable) != 10 {
 		panic("not 11 or 10")
 	}

--- a/cpf_test.go
+++ b/cpf_test.go
@@ -6,8 +6,16 @@ var cpfSink CPF
 
 func BenchmarkGenerateCPF(b *testing.B) {
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		cpfSink = GenerateCPF()
+	}
+}
+
+func TestGenerateCPF(t *testing.T) {
+	for range 1_000_000 {
+		if cpf := GenerateCPF(); !cpf.IsValid() {
+			t.Errorf("invalid CPF generated: %s", string(cpf))
+		}
 	}
 }
 
@@ -18,7 +26,7 @@ func BenchmarkCPF_IsValid14(b *testing.B) {
 		b.FailNow()
 	}
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		boolSink = cpf.IsValid()
 	}
 }
@@ -30,7 +38,7 @@ func BenchmarkCPF_IsValid11(b *testing.B) {
 		b.FailNow()
 	}
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		boolSink = cpf.IsValid()
 	}
 }
@@ -42,7 +50,7 @@ func BenchmarkCPF_IsValid14Invalid(b *testing.B) {
 		b.FailNow()
 	}
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		boolSink = cpf.IsValid()
 	}
 }
@@ -54,7 +62,7 @@ func BenchmarkCPF_IsValid11Invalid(b *testing.B) {
 		b.FailNow()
 	}
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		boolSink = cpf.IsValid()
 	}
 }
@@ -66,7 +74,7 @@ func BenchmarkCPF_String14(b *testing.B) {
 		b.FailNow()
 	}
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		stringSink = cpf.String()
 	}
 }
@@ -78,16 +86,8 @@ func BenchmarkCPF_String11(b *testing.B) {
 		b.FailNow()
 	}
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		stringSink = cpf.String()
-	}
-}
-
-func TestGenerateCPF(t *testing.T) {
-	for range 1_000_000 {
-		if cpf := GenerateCPF(); !cpf.IsValid() {
-			t.Errorf("invalid CPF generated: %s", string(cpf))
-		}
 	}
 }
 

--- a/utils.go
+++ b/utils.go
@@ -41,3 +41,28 @@ func randomDigit() byte {
 
 	return byte(hi) + '0'
 }
+
+var alphaNumericals = []byte{
+	'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H',
+	'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P',
+	'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X',
+	'Y', 'Z',
+	'0', '1', '2', '3', '4', '5', '6', '7',
+	'8', '9',
+}
+
+func randomAlphaNumericalUpper() byte {
+	n := uint64(len(alphaNumericals))
+
+	// This code here is taken from the stdlib.
+	// You can check it at the math/rand/v2 package under func '(r *Rand) uint64n(n uint64) uint64'.
+	hi, lo := bits.Mul64(pcg.Uint64(), n)
+	if lo < n {
+		thresh := -n % n
+		for lo < thresh {
+			hi, lo = bits.Mul64(pcg.Uint64(), n)
+		}
+	}
+
+	return alphaNumericals[int(hi)]
+}


### PR DESCRIPTION
```
goos: linux
goarch: amd64
pkg: github.com/phenpessoa/br
cpu: Intel(R) Core(TM) Ultra 7 155H
                         │   old.txt   │               new.txt                │
                         │   sec/op    │    sec/op     vs base                │
CNPJ_IsValid18-21          40.70n ± 2%   26.92n ±  3%  -33.85% (p=0.000 n=10)
CNPJ_IsValid14-21          43.59n ± 2%   18.79n ±  1%  -56.91% (p=0.000 n=10)
CNPJ_IsValid18Invalid-21   40.29n ± 1%   26.71n ±  3%  -33.69% (p=0.000 n=10)
CNPJ_IsValid14Invalid-21   43.96n ± 1%   18.64n ±  1%  -57.60% (p=0.000 n=10)
CNPJ_String18-21           61.80n ± 5%   48.02n ± 11%  -22.30% (p=0.000 n=10)
CNPJ_String14-21           98.23n ± 0%   75.81n ±  1%  -22.82% (p=0.000 n=10)
geomean                    51.69n        31.17n        -39.70%
```