### PR TITLE
perf: improve CPF algorithm performance

### DIFF
--- a/cpf.go
+++ b/cpf.go
@@ -38,8 +38,8 @@ func GenerateCPF() CPF {
 	}
 
 	var cacheSum int
-	data[12], cacheSum, _ = CpfIterFirst14(data)
-	data[13], _ = CpfIterSecond14(data, cacheSum)
+	data[12], cacheSum, _ = cpfIterFirst14(data)
+	data[13], _ = cpfIterSecond14(data, cacheSum)
 
 	return CPF(string(data))
 }
@@ -74,7 +74,7 @@ func (cpf CPF) IsValid() bool {
 			return false
 		}
 
-		dByte, cacheSum, ok := CpfIterFirst14(cpf)
+		dByte, cacheSum, ok := cpfIterFirst14(cpf)
 		if !ok {
 			return false
 		}
@@ -83,7 +83,7 @@ func (cpf CPF) IsValid() bool {
 			return false
 		}
 
-		dByte, ok = CpfIterSecond14(cpf, cacheSum)
+		dByte, ok = cpfIterSecond14(cpf, cacheSum)
 		if !ok {
 			return false
 		}
@@ -94,7 +94,7 @@ func (cpf CPF) IsValid() bool {
 	}
 }
 
-func CpfIterFirst14[T string | CPF | []byte](cpf T) (byte, int, bool) {
+func cpfIterFirst14[T string | CPF | []byte](cpf T) (byte, int, bool) {
 	if len(cpf) != 14 || len(cpfFirstTable) != 9 {
 		panic("not 14 or 9")
 	}
@@ -140,7 +140,7 @@ func CpfIterFirst14[T string | CPF | []byte](cpf T) (byte, int, bool) {
 	return byte(out) + '0', cacheSum + sum, true
 }
 
-func CpfIterSecond14[T string | CPF | []byte](cpf T, sum int) (byte, bool) {
+func cpfIterSecond14[T string | CPF | []byte](cpf T, sum int) (byte, bool) {
 	if len(cpf) != 14 {
 		panic("not 14 or 10")
 	}

--- a/cpf.go
+++ b/cpf.go
@@ -37,8 +37,9 @@ func GenerateCPF() CPF {
 		data[i] = randomDigit()
 	}
 
-	data[12], _ = cpfIterFirst14(data)
-	data[13], _ = cpfIterSecond14(data)
+	var cacheSum int
+	data[12], cacheSum, _ = CpfIterFirst14(data)
+	data[13], _ = CpfIterSecond14(data, cacheSum)
 
 	return CPF(string(data))
 }
@@ -46,18 +47,14 @@ func GenerateCPF() CPF {
 // ErrInvalidCPF is an error returned when an invalid CPF is encountered.
 var ErrInvalidCPF = errors.New("br: invalid cpf")
 
-// cpf tables
-var (
-	cpfFirstTable  = []int{10, 9, 8, 7, 6, 5, 4, 3, 2}
-	cpfSecondTable = []int{11, 10, 9, 8, 7, 6, 5, 4, 3, 2}
-)
+var cpfFirstTable = []int{10, 9, 8, 7, 6, 5, 4, 3, 2}
 
 // IsValid checks whether the provided CPF is valid based on its checksum
 // digits.
 func (cpf CPF) IsValid() bool {
 	switch len(cpf) {
 	case 11:
-		dByte, ok := cpfIterFirst11(cpf)
+		dByte, cacheSum, ok := cpfIterFirst11(cpf)
 		if !ok {
 			return false
 		}
@@ -66,7 +63,7 @@ func (cpf CPF) IsValid() bool {
 			return false
 		}
 
-		dByte, ok = cpfIterSecond11(cpf)
+		dByte, ok = cpfIterSecond11(cpf, cacheSum)
 		if !ok {
 			return false
 		}
@@ -77,7 +74,7 @@ func (cpf CPF) IsValid() bool {
 			return false
 		}
 
-		dByte, ok := cpfIterFirst14(cpf)
+		dByte, cacheSum, ok := CpfIterFirst14(cpf)
 		if !ok {
 			return false
 		}
@@ -86,7 +83,7 @@ func (cpf CPF) IsValid() bool {
 			return false
 		}
 
-		dByte, ok = cpfIterSecond14(cpf)
+		dByte, ok = CpfIterSecond14(cpf, cacheSum)
 		if !ok {
 			return false
 		}
@@ -97,35 +94,41 @@ func (cpf CPF) IsValid() bool {
 	}
 }
 
-func cpfIterFirst14[T string | CPF | []byte](cpf T) (byte, bool) {
+func CpfIterFirst14[T string | CPF | []byte](cpf T) (byte, int, bool) {
 	if len(cpf) != 14 || len(cpfFirstTable) != 9 {
 		panic("not 14 or 9")
 	}
 
-	var sum, rest, out int
+	var sum, cacheSum, rest, out int
 
 	for i, d := range cpfFirstTable[:3] {
 		cur := cpf[i]
 		if !isDigit(cur) {
-			return 0, false
+			return 0, 0, false
 		}
-		sum += d * int(cur-'0')
+		parsed := int(cur - '0')
+		sum += d * parsed
+		cacheSum += parsed
 	}
 
 	for i, d := range cpfFirstTable[3:6] {
 		cur := cpf[4:7][i]
 		if !isDigit(cur) {
-			return 0, false
+			return 0, 0, false
 		}
-		sum += d * int(cur-'0')
+		parsed := int(cur - '0')
+		sum += d * parsed
+		cacheSum += parsed
 	}
 
 	for i, d := range cpfFirstTable[6:9] {
 		cur := cpf[8:11][i]
 		if !isDigit(cur) {
-			return 0, false
+			return 0, 0, false
 		}
-		sum += d * int(cur-'0')
+		parsed := int(cur - '0')
+		sum += d * parsed
+		cacheSum += parsed
 	}
 
 	rest = sum % 11
@@ -134,45 +137,21 @@ func cpfIterFirst14[T string | CPF | []byte](cpf T) (byte, bool) {
 		out = 11 - rest
 	}
 
-	return byte(out) + '0', true
+	return byte(out) + '0', cacheSum + sum, true
 }
 
-func cpfIterSecond14[T string | CPF | []byte](cpf T) (byte, bool) {
-	if len(cpf) != 14 || len(cpfSecondTable) != 10 {
+func CpfIterSecond14[T string | CPF | []byte](cpf T, sum int) (byte, bool) {
+	if len(cpf) != 14 {
 		panic("not 14 or 10")
 	}
 
-	var sum, rest, out int
-
-	for i, d := range cpfSecondTable[:3] {
-		cur := cpf[i]
-		if !isDigit(cur) {
-			return 0, false
-		}
-		sum += d * int(cur-'0')
-	}
-
-	for i, d := range cpfSecondTable[3:6] {
-		cur := cpf[4:7][i]
-		if !isDigit(cur) {
-			return 0, false
-		}
-		sum += d * int(cur-'0')
-	}
-
-	for i, d := range cpfSecondTable[6:9] {
-		cur := cpf[8:11][i]
-		if !isDigit(cur) {
-			return 0, false
-		}
-		sum += d * int(cur-'0')
-	}
+	var rest, out int
 
 	last := cpf[12]
 	if !isDigit(last) {
 		return 0, false
 	}
-	sum += cpfSecondTable[9] * int(last-'0')
+	sum += 2 * int(last-'0')
 
 	rest = sum % 11
 
@@ -183,19 +162,21 @@ func cpfIterSecond14[T string | CPF | []byte](cpf T) (byte, bool) {
 	return byte(out) + '0', true
 }
 
-func cpfIterFirst11[T string | CPF | []byte](cpf T) (byte, bool) {
+func cpfIterFirst11[T string | CPF | []byte](cpf T) (byte, int, bool) {
 	if len(cpf) != 11 || len(cpfFirstTable) != 9 {
 		panic("not 11 or 9")
 	}
 
-	var sum, rest, out int
+	var sum, cacheSum, rest, out int
 
 	for i, d := range cpfFirstTable {
 		cur := cpf[i]
 		if !isDigit(cur) {
-			return 0, false
+			return 0, 0, false
 		}
-		sum += d * int(cur-'0')
+		parsed := int(cur - '0')
+		sum += d * parsed
+		cacheSum += parsed
 	}
 
 	rest = sum % 11
@@ -204,23 +185,21 @@ func cpfIterFirst11[T string | CPF | []byte](cpf T) (byte, bool) {
 		out = 11 - rest
 	}
 
-	return byte(out) + '0', true
+	return byte(out) + '0', cacheSum + sum, true
 }
 
-func cpfIterSecond11[T string | CPF | []byte](cpf T) (byte, bool) {
-	if len(cpf) != 11 || len(cpfSecondTable) != 10 {
+func cpfIterSecond11[T string | CPF | []byte](cpf T, sum int) (byte, bool) {
+	if len(cpf) != 11 {
 		panic("not 11 or 10")
 	}
 
-	var sum, rest, out int
+	var rest, out int
 
-	for i, d := range cpfSecondTable {
-		cur := cpf[i]
-		if !isDigit(cur) {
-			return 0, false
-		}
-		sum += d * int(cur-'0')
+	last := cpf[9]
+	if !isDigit(last) {
+		return 0, false
 	}
+	sum += 2 * int(last-'0')
 
 	rest = sum % 11
 

--- a/cpf.go
+++ b/cpf.go
@@ -142,7 +142,7 @@ func cpfIterFirst14[T string | CPF | []byte](cpf T) (byte, int, bool) {
 
 func cpfIterSecond14[T string | CPF | []byte](cpf T, sum int) (byte, bool) {
 	if len(cpf) != 14 {
-		panic("not 14 or 10")
+		panic("not 14")
 	}
 
 	var rest, out int
@@ -190,7 +190,7 @@ func cpfIterFirst11[T string | CPF | []byte](cpf T) (byte, int, bool) {
 
 func cpfIterSecond11[T string | CPF | []byte](cpf T, sum int) (byte, bool) {
 	if len(cpf) != 11 {
-		panic("not 11 or 10")
+		panic("not 11")
 	}
 
 	var rest, out int


### PR DESCRIPTION
The second CPF table can be completely elided, not requiring the algorithm
to iterate over it at all.

Ignoring the last digit on the second CPF table we have:

```
S1  = cpf[0] * 10 + cpf[1] *  9 ... cpf[9] * 2
S2' = cpf[0] * 11 + cpf[1] * 10 ... cpf[9] * 3
```

Each digit is multiplied by different weights in S1 and S2,
however the difference for each digit's weights is always +1.
Thus, the difference between S2' and S1 is simply the sum of the digits:

```
S2' - S1 = cpf[0] + cpf[1] + ... cpf[9]
S2' = S1 + cpf[0] + cpf[1] + ... cpf[9]
```

And then, to get the value of S2 we can just add 2 * cpf[10] to S2',
which is the last element of the second CPF table multiplied by the first
verifying digit of the CPF.

```
S2 = S2' + 2 * cpf[10]
```

```
goos: linux
goarch: amd64
pkg: github.com/phenpessoa/br
cpu: Intel(R) Core(TM) Ultra 7 155H
                        │   old.txt    │              new2.txt               │
                        │    sec/op    │   sec/op     vs base                │
GenerateCPF-21             44.02n ± 1%   38.90n ± 5%  -11.62% (p=0.000 n=10)
CPF_IsValid14-21          16.030n ± 1%   9.557n ± 1%  -40.38% (p=0.000 n=10)
CPF_IsValid11-21          12.610n ± 3%   7.927n ± 4%  -37.13% (p=0.000 n=10)
CPF_IsValid14Invalid-21   15.685n ± 2%   9.450n ± 1%  -39.75% (p=0.000 n=10)
CPF_IsValid11Invalid-21   12.530n ± 2%   7.915n ± 1%  -36.84% (p=0.000 n=10)
CPF_String14-21            16.68n ± 1%   10.29n ± 2%  -38.26% (p=0.000 n=10)
CPF_String11-21            27.50n ± 1%   23.41n ± 2%  -14.91% (p=0.000 n=10)
geomean                    18.71n        12.69n       -32.15%
```